### PR TITLE
Associate TV data in vxResource with the specific versions of vxTemplateVar

### DIFF
--- a/assets/components/versionx/js/mgr/common/grid.common.js
+++ b/assets/components/versionx/js/mgr/common/grid.common.js
@@ -2,7 +2,7 @@ Ext.ns('VersionX.grid.Common');
 
 VersionX.grid.Common.DetailGrid = function(config) {
     config = config || {};
-    Ext.apply(config,{
+    Ext.applyIf(config,{
         autoHeight: true,
         width: '98%',
         viewConfig: {

--- a/assets/components/versionx/js/mgr/resources/detailpanel/panel.tvs.js
+++ b/assets/components/versionx/js/mgr/resources/detailpanel/panel.tvs.js
@@ -7,7 +7,7 @@ VersionX.panel.ResourcesDetail.TVs = function(config) {
         if ( typeof config.vxRecord.tvs[key].caption != 'undefined' ) {
             data.push([
                 config.vxRecord.tvs[key].id,
-                config.vxRecord.tvs[key].version,
+                config.vxRecord.tvs[key].version ? config.vxRecord.tvs[key].version : 'N/A',
                 config.vxRecord.tvs[key].caption,
                 config.vxRecord.tvs[key].value
             ]);
@@ -33,7 +33,7 @@ VersionX.panel.ResourcesDetail.TVs = function(config) {
             if ( typeof config.vxRecordCmp.tvs[key].caption != 'undefined' ) {
                 dataCmp.push([
                 config.vxRecordCmp.tvs[key].id,
-                config.vxRecordCmp.tvs[key].version,
+                config.vxRecordCmp.tvs[key].version ? config.vxRecordCmp.tvs[key].version : 'N/A',
                 config.vxRecordCmp.tvs[key].caption,
                 config.vxRecordCmp.tvs[key].value
                 ]);

--- a/assets/components/versionx/js/mgr/resources/detailpanel/panel.tvs.js
+++ b/assets/components/versionx/js/mgr/resources/detailpanel/panel.tvs.js
@@ -1,44 +1,100 @@
+Ext.ns('VersionX.panel.ResourcesDetail');
 VersionX.panel.ResourcesDetail.TVs = function(config) {
     config = config || {};
     
-    var vxTemplateVars = [];    
-    for ( key in config.vxRecord.tvs ) {
-        var id = config.vxRecord.tvs[key].id;
-        if ( ! vxTemplateVars[id] ) {
-            vxTemplateVars[id] = config.vxRecord.tvs[key];
-        }
-    }
-    if ( config.vxRecordCmp ) {
-        for ( key in config.vxRecordCmp.tvs ) {
-            var id = config.vxRecordCmp.tvs[key].id;
-            if ( ! vxTemplateVars[id] ) {
-                vxTemplateVars[id] = config.vxRecordCmp.tvs[key];
-                vxTemplateVars[id].value = ''; 
-            }
-            vxTemplateVars[id].cm_value = config.vxRecordCmp.tvs[key].value;
-        }
-    }
-    
     var data = [];
-    for ( key in vxTemplateVars ) {
-        if ( typeof vxTemplateVars[key].caption != 'undefined' ) {
+    for ( key in config.vxRecord.tvs ) {
+        if ( typeof config.vxRecord.tvs[key].caption != 'undefined' ) {
             data.push([
-                vxTemplateVars[key].caption,
-                vxTemplateVars[key].value,
-                vxTemplateVars[key].cm_value
+                config.vxRecord.tvs[key].id,
+                config.vxRecord.tvs[key].version,
+                config.vxRecord.tvs[key].caption,
+                config.vxRecord.tvs[key].value
             ]);
         }
     }
-    
+   
     Ext.apply(config,{
-        items: [{
-            xtype: 'versionx-grid-common-detailgrid',
-            vxRecord: config.vxRecord,
-            vxRecordCmp: config.vxRecordCmp ? config.vxRecordCmp : undefined,
-            data: data
+        items:[{
+            layout: 'column',
+            border: false,
+            items: [{
+                columnWidth: 1,
+                xtype: 'versionx-grid-resourcesdetail-tvs',
+                vxRecord: config.vxRecord,
+                data: data
+            }]
         }]
     });    
+    
+    if (config.vxRecordCmp) {
+        var dataCmp = [];
+        for ( key in config.vxRecordCmp.tvs ) {
+            if ( typeof config.vxRecordCmp.tvs[key].caption != 'undefined' ) {
+                dataCmp.push([
+                config.vxRecordCmp.tvs[key].id,
+                config.vxRecordCmp.tvs[key].version,
+                config.vxRecordCmp.tvs[key].caption,
+                config.vxRecordCmp.tvs[key].value
+                ]);
+            }
+        }
+
+        config.items[0].items[0].columnWidth = 0.5;
+        config.items[0].items.push({
+            columnWidth: .5,
+            xtype: 'versionx-grid-resourcesdetail-tvs',
+            vxRecord: config.vxRecordCmp,
+            data: dataCmp
+        });
+        
+    }
+    
     VersionX.panel.ResourcesDetail.TVs.superclass.constructor.call(this,config);
 };
 Ext.extend(VersionX.panel.ResourcesDetail.TVs,MODx.Panel,{});
 Ext.reg('versionx-panel-resourcesdetail-tvs',VersionX.panel.ResourcesDetail.TVs);
+
+
+Ext.ns('VersionX.grid.ResourcesDetail');
+VersionX.grid.ResourcesDetail.TVs = function(config) {
+    config = config || {};
+    Ext.applyIf(config, {
+        fields: [
+            {name: 'tvID', type: 'string'},
+            {name: 'tvVersion', type: 'string'},
+            {name: 'tvName', type: 'string'},
+            {name: 'tvValue', type: 'string'}
+        ],
+        columns: [
+            {
+                header: _('versionx.resources.detail.tvgrid.columns.tv-id'),
+                dataIndex: 'tvID',
+                sortable: true,
+                width: .075
+            },
+            {
+                header: _('versionx.resources.detail.tvgrid.columns.tv-version'),
+                dataIndex: 'tvVersion',
+                sortable: true,
+                width: .075
+            },
+            {
+                header: _('versionx.resources.detail.tvgrid.columns.tv-name'),
+                dataIndex: 'tvName',
+                sortable: true,
+                width: .3
+            },
+            {
+                header: _('versionx.resources.detail.tvgrid.columns.tv-value', {id:config.vxRecord.version_id}),
+                dataIndex: 'tvValue',
+                sortable: true,
+                width: .5
+            }
+        ]
+    })
+    VersionX.grid.ResourcesDetail.TVs.superclass.constructor.call(this,config);
+};
+Ext.extend(VersionX.grid.ResourcesDetail.TVs,VersionX.grid.Common.DetailGrid,{});
+Ext.reg('versionx-grid-resourcesdetail-tvs',VersionX.grid.ResourcesDetail.TVs);
+

--- a/core/components/versionx/lexicon/en/default.inc.php
+++ b/core/components/versionx/lexicon/en/default.inc.php
@@ -39,6 +39,11 @@ $_lang['versionx.resources.detail.tabs.page-settings'] = 'Page Settings';
 $_lang['versionx.resources.detail.grid.columns.field-name'] = 'Field Name';
 $_lang['versionx.resources.detail.grid.columns.field-value'] = 'Field Value [Ver #[[+id]]]';
 
+$_lang['versionx.resources.detail.tvgrid.columns.tv-id'] = 'ID';
+$_lang['versionx.resources.detail.tvgrid.columns.tv-version'] = 'Ver';
+$_lang['versionx.resources.detail.tvgrid.columns.tv-name'] = 'Caption';
+$_lang['versionx.resources.detail.tvgrid.columns.tv-value'] = 'Value';
+
 $_lang['versionx.templates.detail.tabs.version-details'] = 'Version Details';
 $_lang['versionx.templates.detail.tabs.fields'] = 'Fields';
 $_lang['versionx.templates.detail.tabs.content'] = 'Content';

--- a/core/components/versionx/model/versionx.class.php
+++ b/core/components/versionx/model/versionx.class.php
@@ -400,16 +400,31 @@ class VersionX {
                 /* Get TV captions */
                 $tvArray = array();
                 foreach ($vArray['tvs'] as $tv) {
-                    if (!$this->tvs[$tv['id']]) {
-                        /* @var modTemplateVar $tvObj */
-                        $tvObj = $this->modx->getObject('modTemplateVar',$tv['id']);
-                        if ($tvObj instanceof modTemplateVar) {
-                            $this->tvs[$tv['id']] = $tvObj->get('caption');
+                    if (!$tvArray[$tv['id']]) {
+                        // Look up TV by it's version #
+                        if (isset($tv['version'])) {
+                            $vxTVObj = $this->modx->getObject('vxTemplateVar', array('version_id' => $tv['version']));
+                            if ($vxTVObj instanceof vxTemplateVar) {
+                                $tvArray[$vxTVObj->get('content_id')] = array_merge($tv,array(
+                                    'caption' => $vxTVObj->get('caption'),
+                                ));
+                            }
+                        }
+
+                        // If lookup above did nothing, get details of the currently-active TV
+                        if (!$tvArray[$tv['id']]) {
+                            /* @var modTemplateVar $tvObj */
+                            $tvObj = $this->modx->getObject('modTemplateVar',$tv['id']);
+                            if ($tvObj instanceof modTemplateVar) {
+                                $tvArray[$tv['id']] = array_merge($tv,array(
+                                    'caption' => $tvObj->get('caption'),
+                                    'version' => 0
+                                ));
+                            }
                         }
                     }
-                    $tvArray[] = array_merge($tv,array('caption' => $this->tvs[$tv['id']]));
                 }
-                $vArray['tvs'] = $tvArray;
+                $vArray['tvs'] = array_values($tvArray);
             }
 
             /* @var modUserProfile $up */

--- a/core/components/versionx/model/versionx.class.php
+++ b/core/components/versionx/model/versionx.class.php
@@ -171,7 +171,22 @@ class VersionX {
         $tvArray = array();
         /* @var modTemplateVar $tv */
         foreach ($tvs as $tv) {
-            $tvArray[] = $tv->get(array('id','value'));
+            $tvArr = $tv->get(array('id','value'));
+            
+            // Ensure there is a version of the TV saved
+            $this->newTemplateVarVersion($tv);
+            
+            // Get the most current version of the TV
+            $tvQuery = $this->modx->newQuery('vxTemplateVar');
+            $tvQuery->where(array('content_id' => $tv->get('id')))
+                ->sortby('saved', 'DESC')
+                ->limit(1);
+            $tvVersion = $this->modx->getObject('vxTemplateVar', $tvQuery);
+            if ($tvVersion instanceof vxTemplateVar) {            
+                $tvArr['version'] = $tvVersion->get('version_id');
+            }
+            
+            $tvArray[] = $tvArr;
         }
         $version->set('tvs',$tvArray);
 


### PR DESCRIPTION
On saving a new version of a Resource, also store the versions of any Template Variables associated with the Resource.  This is accomplished by adding an additional key ("version") to each entry in the "tvs" array field of vxResource at save time.  I've also updated the "Template Variables" tab of the "VersionX Resource Details" page to display the version # for each TV. 
