### PR TITLE
Fix resourcegroup saving fail bc of #8992

### DIFF
--- a/core/components/versionx/model/versionx.class.php
+++ b/core/components/versionx/model/versionx.class.php
@@ -289,6 +289,11 @@ class VersionX {
             $chunk = $this->modx->getObject('modChunk', (int)$chunk);
         }
 
+        // prevents resource groups from failing in MODX versions prior to 2.2.14 (see github #8992 + fix)
+        if (!($chunk instanceof modChunk)) {
+            return false;
+        }
+
         $cArray = $chunk->toArray();
 
         /* @var vxChunk $version */


### PR DESCRIPTION
The added check makes sure the $chunk variable is really a modChunk object. If this is not done saving a new resource group fails with save till death...this is because of a core bug (PR sent: https://github.com/modxcms/revolution/pull/11351) which mistakenly triggers OnChunkFormSave (when saving a resource group) instead of OnResourceGroupSave, which then in turn triggers versionx with no $chunk variable passed to the plugin...this causes a fatal error on line 292 because of $chunk->toArray() on a non-object...

not sure if you want to wait till the PR is merged into the core or if you want to include this in a future update to make sure also older versions of modx work properly without the core fix...
