### PR TITLE
return false if it's not saved

### DIFF
--- a/core/components/versionx/model/versionx.class.php
+++ b/core/components/versionx/model/versionx.class.php
@@ -201,7 +201,7 @@ class VersionX {
         if($this->checkLastVersion('vxResource', $version, $this->debug)) {
             return $version->save();
         }
-        return true;
+        return FALSE;
     }
 
 


### PR DESCRIPTION
When we used your class, we could not detect whether the saving succeeded or not, because the saving function itself is wrapped in a condition

```
        if($this->checkLastVersion('vxResource', $version, $this->debug)) {
            return $version->save();
        }
```

This particular method should return false at the end, to mark that there is no `newResourceVersion` is made because no condition is met
