### PR TITLE
Check the modTemplateVar object before using it

### DIFF
--- a/core/components/versionx/migrate.php
+++ b/core/components/versionx/migrate.php
@@ -210,7 +210,9 @@ function mergeTVs($object): array
     $tvs = [];
     foreach ($object->get('tvs') as $tvContent) {
         $tmpVar = $modx->getObject('modTemplateVar', $tvContent['id']);
-        $tvs[$tmpVar->get('name')] = $tvContent['value'];
+        if ($tmpVar) {
+            $tvs[$tmpVar->get('name')] = $tvContent['value'];
+        }
     }
 
     return array_merge(


### PR DESCRIPTION
Fix the fatal error:

```
Uncaught Error: Call to a member function get() on null in /.../core/components/versionx/migrate.php:213
```