### PR TITLE
Revert fields to original types

### DIFF
--- a/_build/resolvers/tables.resolver.php
+++ b/_build/resolvers/tables.resolver.php
@@ -30,6 +30,14 @@ if ($object->xpdo) {
                 $manager->createObjectContainer($obj);
             }
 
+            // Set to fatal errors only while updating database, to avoid false positives displayed.
+            $modx->setLogLevel(modX::LOG_LEVEL_FATAL);
+
+            // VersionX 3.1.1
+            // These fields are added to keep track of data types to be used when reverting
+            $manager->addField('vxDeltaField', 'before_type', ['after' => 'field_type']);
+            $manager->addField('vxDeltaField', 'after_type', ['after' => 'before_type']);
+
             $modx->setLogLevel($loglevel);
 
         break;

--- a/_build/schema/versionx.mysql.schema.xml
+++ b/_build/schema/versionx.mysql.schema.xml
@@ -97,6 +97,12 @@
         <field key="field" dbtype="varchar" precision="128" phptype="string" null="false" />
         <!-- Support different field types that may render differently, e.g. image, binary, commerce_product.. -->
         <field key="field_type" dbtype="varchar" precision="128" phptype="string" null="false" default="text" />
+        <!--
+            Keep track of the before and after value types so reverting doesn't decode an intended json string,
+            or cast an int as a string etc. Empty value means it's a string.
+        -->
+        <field key="before_type" dbtype="varchar" precision="20" phptype="string" null="false" default="" />
+        <field key="after_type" dbtype="varchar" precision="20" phptype="string" null="false" default="" />
 
         <field key="before" dbtype="mediumtext" phptype="string" null="false" default="" />
         <field key="after" dbtype="mediumtext" phptype="string" null="false" default="" />

--- a/_build/schema/versionx.mysql.schema.xml
+++ b/_build/schema/versionx.mysql.schema.xml
@@ -101,8 +101,8 @@
             Keep track of the before and after value types so reverting doesn't decode an intended json string,
             or cast an int as a string etc. Empty value means it's a string.
         -->
-        <field key="before_type" dbtype="varchar" precision="20" phptype="string" null="false" default="" />
-        <field key="after_type" dbtype="varchar" precision="20" phptype="string" null="false" default="" />
+        <field key="before_type" dbtype="varchar" precision="7" phptype="string" null="false" default="" />
+        <field key="after_type" dbtype="varchar" precision="7" phptype="string" null="false" default="" />
 
         <field key="before" dbtype="mediumtext" phptype="string" null="false" default="" />
         <field key="after" dbtype="mediumtext" phptype="string" null="false" default="" />

--- a/core/components/versionx/model/versionx/mysql/vxdeltafield.map.inc.php
+++ b/core/components/versionx/model/versionx/mysql/vxdeltafield.map.inc.php
@@ -34,6 +34,8 @@ $xpdo_meta_map['vxDeltaField']= array (
     'delta' => 0,
     'field' => NULL,
     'field_type' => 'text',
+    'before_type' => '',
+    'after_type' => '',
     'before' => '',
     'after' => '',
   ),
@@ -62,6 +64,22 @@ $xpdo_meta_map['vxDeltaField']= array (
       'phptype' => 'string',
       'null' => false,
       'default' => 'text',
+    ),
+    'before_type' => 
+    array (
+      'dbtype' => 'varchar',
+      'precision' => '20',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'after_type' => 
+    array (
+      'dbtype' => 'varchar',
+      'precision' => '20',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
     ),
     'before' => 
     array (

--- a/core/components/versionx/model/versionx/mysql/vxdeltafield.map.inc.php
+++ b/core/components/versionx/model/versionx/mysql/vxdeltafield.map.inc.php
@@ -68,7 +68,7 @@ $xpdo_meta_map['vxDeltaField']= array (
     'before_type' => 
     array (
       'dbtype' => 'varchar',
-      'precision' => '20',
+      'precision' => '7',
       'phptype' => 'string',
       'null' => false,
       'default' => '',
@@ -76,7 +76,7 @@ $xpdo_meta_map['vxDeltaField']= array (
     'after_type' => 
     array (
       'dbtype' => 'varchar',
-      'precision' => '20',
+      'precision' => '7',
       'phptype' => 'string',
       'null' => false,
       'default' => '',

--- a/core/components/versionx/src/Fields/Field.php
+++ b/core/components/versionx/src/Fields/Field.php
@@ -12,6 +12,18 @@ abstract class Field
     protected array $options = [];
     protected string $tpl = '';
 
+    public const ACCEPTED_VALUE_TYPES = [
+        'array',
+        'object',
+        'boolean',
+        'bool',
+        'integer',
+        'int',
+        'float',
+        'double',
+        'null'
+    ];
+
     function __construct($value, $name = '', $options = [])
     {
         if (!$this->value) {

--- a/core/components/versionx/src/Fields/Properties.php
+++ b/core/components/versionx/src/Fields/Properties.php
@@ -63,21 +63,17 @@ class Properties extends Field
                 continue;
             }
 
+            // The last 'piece' will be the key we're after.
             if ($piece === $last) {
-//                $json = json_decode($field->get('before'), true);
-//                if (json_last_error() === JSON_ERROR_NONE) {
-//                    $data[$piece] = $json;
-//                }
-
                 $beforeValue = $field->get('before');
                 $beforeType = $field->get('before_type');
 
-                if ($beforeType === 'array') {
-                    // Unserialize if it's meant to be an array
-                    $unserialized = unserialize($beforeValue);
-                    $data[$piece] = $unserialized !== false ? $unserialized : $field->get('before');
+                if (in_array($beforeType, ['array', 'object'])) {
+                    // Decode if it's meant to be an array/object
+                    $decoded = json_decode($beforeValue, true);
+                    $data[$piece] = $decoded ?: $field->get('before');
                 }
-                else if (in_array($beforeType, ['boolean', 'bool', 'integer', 'int', 'float', 'double'])) {
+                else if (in_array(strtolower($beforeType), self::ACCEPTED_VALUE_TYPES)) {
                     // Cast as the set type
                     $data[$piece] = settype($beforeValue, $beforeType);
                 }

--- a/core/components/versionx/src/Types/Type.php
+++ b/core/components/versionx/src/Types/Type.php
@@ -184,7 +184,7 @@ abstract class Type
     }
 
     /**
-     * Runs before object being reverted is saved.
+     * Runs after main object revert, and before the object is saved.
      * @param string $action - 'all', 'delta', or 'single'
      * @param array $fields - the delta fields that are being saved to the object
      * @param \xPDOObject $object - the object being reverted
@@ -287,7 +287,7 @@ abstract class Type
             ) {
                 // Take current properties field value and insert the "before" version at matching array keys.
                 $data = $object->get($propField);
-                Properties::revertPropertyValue($field, $data, 'before');
+                Properties::revertPropertyValue($field, $data);
                 $object->set($propField, $data);
                 $object->save();
             }

--- a/core/components/versionx/src/Utils.php
+++ b/core/components/versionx/src/Utils.php
@@ -2,8 +2,8 @@
 
 namespace modmore\VersionX;
 
-class Utils {
-
+class Utils
+{
     /**
      * Flattens an array recursively, and returns other values as a string
      * @param mixed $array
@@ -12,7 +12,9 @@ class Utils {
      */
     public static function flattenArray($array = []): string
     {
-        if (!is_array($array)) return (string)$array;
+        if (!is_array($array)) {
+            return (string)$array;
+        }
 
         $string = [];
         foreach ($array as $key => $value) {


### PR DESCRIPTION
Still testing...

The new fields might be better off as a combined properties field. 🤔 

There are some issues reverting properties fields. We can't just decode or deserialize all properties when reverting because some may be intended to be that way.

This PR adds a way to keep track of what the value type was before it was added to the delta field. This way we can serialize an array when creating a delta, and then we know that it needs to be unserialized when reverting. 
It also will allow an integer to be recreated as an integer etc.

This also fixes a bug with a blank array key being created when splitting property fields recursively.

