### PR TITLE
Detect if $object->get('fields') is an array

### DIFF
--- a/core/components/versionx/migrate.php
+++ b/core/components/versionx/migrate.php
@@ -221,7 +221,7 @@ function mergeTVs($object): array
     }
 
     return array_merge(
-        $object->get('fields'),
+        !empty($object->get('fields')) ? $object->get('fields') : [],
         ['content' => $object->get('content')],
         $tvs,
     );


### PR DESCRIPTION
Was getting `false` when calling `$object->get('fields')` on a certain resources. 

Fixes issue #128