### PR TITLE
fix: Optimize Editor Filter

### DIFF
--- a/assets/components/versionx/js/mgr/versionx.class.js
+++ b/assets/components/versionx/js/mgr/versionx.class.js
@@ -143,7 +143,6 @@ VersionX.combo.Editors = function(config) {
         baseParams: {
             action: 'mgr/filters/editors',
             combo: true,
-            limit: '0',
         },
         emptyText: _('versionx.filters.editor'),
     });

--- a/core/components/versionx/processors/mgr/filters/editors.class.php
+++ b/core/components/versionx/processors/mgr/filters/editors.class.php
@@ -21,6 +21,14 @@ class VersionXEditorsFilterProcessor extends modObjectGetListProcessor
             'username' => 'User.username',
         ]);
 
+        $query = trim($this->getProperty('query'));
+
+        if ($query) {
+            $c->where(['User.username:LIKE' => '%'.$query.'%']);
+        }
+
+        $c->groupBy('User.username');
+
         return $c;
     }
 


### PR DESCRIPTION
Currently, the Editor filter times out and causes 500 errors on large sites with numerous editors and a large number of changes. I've edited the query on the function to reduce the payload so it doesn't cause issues on our site with hundreds of thousands of deltas. 