### PR TITLE
feat: Render view options / Automatic cache clean

### DIFF
--- a/_build/data/settings.php
+++ b/_build/data/settings.php
@@ -53,4 +53,8 @@ return [
         'area' => 'Enable',
         'value' => true,
     ],
+    'renderer' => [
+        'area' => 'Appearance',
+        'value' => 'Inline'
+    ]
 ];

--- a/_build/events/events.versionx.php
+++ b/_build/events/events.versionx.php
@@ -19,6 +19,7 @@ $e = [
     'OnPluginFormPrerender',
 
     'FredOnFredResourceSave',
+    'OnSiteRefresh',
 ];
 
 foreach ($e as $ev) {

--- a/core/components/versionx/elements/plugins/versionx.plugin.php
+++ b/core/components/versionx/elements/plugins/versionx.plugin.php
@@ -164,6 +164,9 @@ switch($eventName) {
         }
 
         break;
+    case 'OnSiteRefresh':
+        $versionX->deltas()->cleanup();
+        break;
 }
 
 return true;

--- a/core/components/versionx/lexicon/en/default.inc.php
+++ b/core/components/versionx/lexicon/en/default.inc.php
@@ -62,3 +62,7 @@ $_lang['versionx.optimize_storage.successful'] = 'Optimization successful';
 $_lang['versionx.widget.resources'] = 'Recent Resource Changes';
 $_lang['versionx.widget.resources.desc'] = '[VersionX] Shows a grid with the most recent resource changes for all users.';
 $_lang['versionx.widget.resources.update'] = 'Update Resource';
+
+// Settings
+$_lang['setting_versionx.renderer'] = 'Renderer';
+$_lang['setting_versionx.renderer_desc'] = 'The renderer to use for the Diff view, options are: "Inline", "SideBySide" and "Combined".';

--- a/core/components/versionx/processors/mgr/deltas/getlist.class.php
+++ b/core/components/versionx/processors/mgr/deltas/getlist.class.php
@@ -132,6 +132,9 @@ class VersionXDeltasGetlistProcessor extends modObjectGetListProcessor {
             return [];
         }
 
+        $options = [
+            'renderer' => $this->modx->getOption('versionx.renderer', null, 'Inline'),
+        ];
         $row['diffs'] = '';
         foreach($fields as $field) {
             // Attempt to get diff from cache
@@ -146,7 +149,7 @@ class VersionXDeltasGetlistProcessor extends modObjectGetListProcessor {
                 // Otherwise calculate diff
                 $fieldType = $this->type->getFieldClass($field->get('field'));
                 $fieldTypeObj = new $fieldType($field->get('after'));
-                $renderedDiff = $fieldTypeObj->render($field->get('before'), $field->get('after'));
+                $renderedDiff = $fieldTypeObj->render($field->get('before'), $field->get('after'), $options);
 
                 // Save in cache
                 if ($renderedDiff) {

--- a/core/components/versionx/src/DeltaManager.php
+++ b/core/components/versionx/src/DeltaManager.php
@@ -43,15 +43,28 @@ class DeltaManager
      * @param string $value
      * @return string
      */
-    public static function calculateDiff(string $prevValue, string $value): string
+    public static function calculateDiff(string $prevValue, string $value, array $options = []): string
     {
+        $renderer = self::getRenderer($options);
         return DiffHelper::calculate(
             $prevValue,
             $value,
-            'Inline',
+            $renderer,
             self::$diffOptions,
             self::$rendererOptions,
         );
+    }
+
+    private static function getRenderer(array $options): string
+    {
+        $valid = [
+            'Inline', 'Combined', 'SideBySide', // HTML
+        ];
+        $renderer = $options['renderer'] ?? 'Inline';
+        if (!in_array($renderer, $valid)) {
+            return 'Inline';
+        }
+        return $renderer;
     }
 
     /**
@@ -84,6 +97,9 @@ class DeltaManager
 
         // Get current principal object
         $object = $this->modx->getObject($type->getClass(), ['id' => $id]);
+        $options = [
+            'renderer' => $this->modx->getOption('versionx.renderer', null, 'Inline'),
+        ];
 
         if (!$type->beforeDeltaCreate($now, $object)) {
             return null;
@@ -141,7 +157,7 @@ class DeltaManager
             }
 
             try {
-                $renderedDiff = $fieldTypeObj->render($prevValue, $value);
+                $renderedDiff = $fieldTypeObj->render($prevValue, $value, $options);
             }
             catch (\Error $e) {
                 $this->modx->log(\modX::LOG_LEVEL_ERROR, '[VersionX] Fatal Error calculating diff: '
@@ -454,5 +470,11 @@ class DeltaManager
         }
 
         return false;
+    }
+
+    public function cleanup(): void
+    {
+        $this->modx->log(\xPDO::LOG_LEVEL_INFO, '[VersionX] Cleaning up cache...');
+        $this->modx->cacheManager->clean(VersionX::CACHE_OPT);
     }
 }

--- a/core/components/versionx/src/Fields/Field.php
+++ b/core/components/versionx/src/Fields/Field.php
@@ -66,6 +66,6 @@ abstract class Field
 
     public function render(string $prevValue, string $newValue, array $options = []): string
     {
-        return DeltaManager::calculateDiff($prevValue, $newValue);
+        return DeltaManager::calculateDiff($prevValue, $newValue, $options);
     }
 }

--- a/core/components/versionx/src/Fields/Image.php
+++ b/core/components/versionx/src/Fields/Image.php
@@ -13,7 +13,7 @@ class Image extends Field
 
     public function render(string $prevValue, string $newValue, array $options = []): string
     {
-        $diff = DeltaManager::calculateDiff($prevValue, $newValue);
+        $diff = DeltaManager::calculateDiff($prevValue, $newValue, $options);
         // todo: render before and after images into diff (process with media source) - templates/mgr/fields/image.tpl
         return $diff;
     }

--- a/core/components/versionx/src/Types/Resource.php
+++ b/core/components/versionx/src/Types/Resource.php
@@ -59,6 +59,9 @@ class Resource extends Type
         // Grab the most recent TV value fields
         $prevFields = $this->versionX->deltas()->getClosestDeltaFields($this, $object, $tvNames);
 
+        $options = [
+            'renderer' => $this->modx->getOption('versionx.renderer', null, 'Inline'),
+        ];
         // Loop through TVs matching previous delta fields by TV name
         /* @var \MODX\Revolution\modTemplateVar|\modTemplateVar $tv */
         foreach ($tvs as $tv) {
@@ -95,7 +98,7 @@ class Resource extends Type
                 'field_type' => get_class($fieldObj),
                 'before' => $prevValue,
                 'after' => $tvValue,
-                'diff' => $fieldObj->render($prevValue, $fieldObj->getValue()),
+                'diff' => $fieldObj->render($prevValue, $fieldObj->getValue(), $options),
             ]);
 
             $fields[] = $field;


### PR DESCRIPTION
This adds the ability to change the renderer from strictly "Inline" to "SideBySide" and "Combined". Mostly because side by side is more how my brain wants to look at diffs. Re: #153

I also tied in cleaning up the cache directory on site_refresh, since there are currently no mechanisms to do that. Re: #152